### PR TITLE
Minor tweak to fix infinite recursion

### DIFF
--- a/iOS_SDK/GameThrive/GameThrive.m
+++ b/iOS_SDK/GameThrive/GameThrive.m
@@ -748,7 +748,7 @@ int getNotificationTypes() {
 
 static Class getClassWithProtocolInHierarchy(Class searchClass, Protocol* protocolToFind) {
     if (!class_conformsToProtocol(searchClass, protocolToFind)) {
-        if ([searchClass superclass] == [NSObject class])
+        if (([searchClass superclass] == [NSObject class]) || ([searchClass superclass] == nil))
             return nil;
         
         Class foundClass = getClassWithProtocolInHierarchy([searchClass superclass], protocolToFind);


### PR DESCRIPTION
NSObject is not always the final class you’ll find, it could be NSProxy
and in this case this method gets into an infinite loop.  It checks to
make sure the superclass of searchClass is not nil which will prevent
infinite recursion.
